### PR TITLE
Implement token caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .coverage
 reports/
 *egg-info
+.env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }

--- a/spivey/auth.py
+++ b/spivey/auth.py
@@ -1,9 +1,14 @@
 import os
 import sys
+from datetime import datetime as dt
+from datetime import timedelta, timezone
 from .http import post
 
 class Auth():
     def __init__(self):
+        self.ttl = 0
+        self._token = None
+
         # load creds
         try:
             self.refresh_token = os.environ['REFRESH_TOKEN']
@@ -20,25 +25,31 @@ class Auth():
 
         # load settings
         self.auth_url = os.getenv('TD_AUTH_URL', 'https://api.tdameritrade.com/v1/oauth2/token')
-        self.timeout  = int(os.getenv('TD_TIMEOUT', '30'))
+        self.timeout = int(os.getenv('TD_TIMEOUT', '30'))
 
     def token(self):
         """
         Generate a bearer token returned as a string.
 
-        CLIENT_ID and REFRESH_TOKEN environment variables are used
-        to auth
+        CLIENT_ID and REFRESH_TOKEN environment variables are used to authenticate
         :return: Bearer token
         :rtype: string
         """
+        if self.ttl:
+            if self.ttl > dt.now(timezone.utc):
+                return self._token
 
         resp = post(self.auth_url, data=self.payload, timeout=self.timeout)
+        payload = resp.json()
         try:
-            _token = resp.json()['access_token']
+            _token = payload['access_token']
+            expiration = payload['expires_in']
         except KeyError as e:
             print(f'{e} missing from response')
             sys.exit(1)
-        return _token
+        self.ttl = dt.now(timezone.utc) + timedelta(seconds=expiration)
+        self._token = _token
+        return self._token
 
     def header(self):
         """


### PR DESCRIPTION
When a token is retrieved it's now added to the `Auth` instance at `self._token`. 
In order to observe a token's expiration, the value of the `expires_in` key that's returned with the token is added to the current time (to determine at what time it expires) then also added to the `Auth` instance at `self.ttl`.  
On subsequent calls to methods that return a token, if the time stored in `self.ttl` hasn't occured yet, then the token is considered valid and returned from `self._token`.